### PR TITLE
Fix for issue 25: selection of empty string properties

### DIFF
--- a/spahql.js
+++ b/spahql.js
@@ -245,7 +245,7 @@ var SpahQL = SpahQL_classExtend("SpahQL", Array, {
     }
     else {
       results = (arguments.length > 1)? Array.prototype.slice.call(arguments) : results;
-      results = (results.value && typeof(results.value)!="function")? [results] : results;
+      results = ((results.value || results.value === '') && typeof(results.value)!="function")? [results] : results;
       for(var i in results) this.push(results[i]);
     }
   },


### PR DESCRIPTION
Simple fix for issue #25. Problem when selecting properties with empty string as value end up as undefined in the results. Only seems to occur when running in the browser.

Note: I'm new to this, so I didn't know how to generate the minified version of spahql.js ... if someone could point me in the right direction please.